### PR TITLE
Better Detection for exported function suffixes.

### DIFF
--- a/lib/ffi-icu/lib.rb
+++ b/lib/ffi-icu/lib.rb
@@ -90,7 +90,7 @@ module ICU
       # Here are the possible suffixes
       suffixes = [""]
       if version
-        suffixes << "_#{version}" << "_#{version[0]}_#{version[1]}"
+        suffixes << "_#{version}" << "_#{version[0].chr}_#{version[1].chr}"
       end
 
       # Try to find the u_errorName function using the possible suffixes


### PR DESCRIPTION
libicu sometimes exports functions suffixed with the libicu version.  Given a function u_errorName, some examples seen int wild include:

u_errorName
u_errorName_44
u_errorName_3_6

This commit adds in code to check each possibility to figure out what the suffix really is.  The last version, u_errorName_3_6, is from CentOS 5, and this commit allows it to be supported.
