### PR TITLE
Added path for libicu48:amd64 on Debian

### DIFF
--- a/lib/ffi-icu/lib.rb
+++ b/lib/ffi-icu/lib.rb
@@ -15,7 +15,8 @@ module ICU
         elsif FFI::Platform::IS_WINDOWS
           ENV['PATH'].split(File::PATH_SEPARATOR)
         else
-          [ '/usr/local/{lib64,lib}', '/opt/local/{lib64,lib}', '/usr/{lib64,lib}' ]
+          [ '/usr/local/{lib64,lib}', '/opt/local/{lib64,lib}',
+            '/usr/{lib64,lib}', '/usr/lib/x86_64-linux-gnu' ]
         end
       end
     end


### PR DESCRIPTION
Hi,

Just little patch for Debian libicu48:amd64 package.
One strange thing is that i have one failing test:

Failures:

  1) ICU::Collation::Collator should compare two strings
     Failure/Error: collator.compare("baah", "blah").should == -1
       expected: -1
            got: 1 (using ==)
     # ./spec/collation_spec.rb:39:in `block (2 levels) in module:Collation'

The package version is 4.8.1.1-6

Thanks,
Laurent
