### PR TITLE
Latest Version breaks pre-libicu 4.0

### DIFF
--- a/lib/ffi-icu/lib.rb
+++ b/lib/ffi-icu/lib.rb
@@ -238,7 +238,7 @@ module ICU
       attach_function :uloc_getLocaleForLCID, "uloc_getLocaleForLCID#{suffix}", [:uint32, :pointer, :int32_t, :pointer], :int32_t
     end
 
-    if Gem::Version.new('4.2') <= Gem::Version.new(self.version)
+    if Gem::Version.new('4.0') <= Gem::Version.new(self.version)
       attach_function :uloc_addLikelySubtags, "uloc_addLikelySubtags#{suffix}", [:string, :pointer, :int32_t, :pointer], :int32_t
       attach_function :uloc_minimizeSubtags,  "uloc_minimizeSubtags#{suffix}",  [:string, :pointer, :int32_t, :pointer], :int32_t
       attach_function :uloc_getCharacterOrientation,  "uloc_getCharacterOrientation#{suffix}",  [:string, :pointer], :layout_type


### PR DESCRIPTION
The latest version of ffi-icu breaks compatibility with older versions of libicu.  We are still using 3.6, which no longer works because the latest gem requires functions that were introduced in libicu 3.8, 4.0 and 4.2.  

I simply followed the lead in lib.rb, and defined the versions over which the functions should be loaded.

Thanks - Charlie
