### PR TITLE
Fix compatibility with JRuby 9000

### DIFF
--- a/lib/ffi-icu/lib.rb
+++ b/lib/ffi-icu/lib.rb
@@ -171,7 +171,7 @@ module ICU
       def to_s
         buffer = FFI::MemoryPointer.new(:char, MaxStringLength)
         Lib.u_versionToString(self, buffer)
-        buffer.read_string_to_null
+        buffer.read_string
       end
     end
 


### PR DESCRIPTION
On JRuby 9.0.1.0, loading ffi-icu fails because FFI::MemoryPointer.read_string_to_null doesn't exist. This was fixed by replacing the call with .read_string. Not sure whether this is specific to JRuby 9000 or JRuby in general, but things worked after this change. Hopefully someone with inside knowledge can confirm that this fix is indeed correct.

```
jruby-9.0.1.0 :001 > require 'ffi-icu'
NoMethodError: undefined method `read_string_to_null' for #<FFI::MemoryPointer address=0x7f64c86db210 size=20>
    from /usr/local/rvm/gems/jruby-9.0.1.0/gems/ffi-icu-0.1.7/lib/ffi-icu/lib.rb:174:in `to_s'
    from /usr/local/rvm/rubies/jruby-9.0.1.0/lib/ruby/stdlib/rubygems/version.rb:172:in `correct?'
    from /usr/local/rvm/rubies/jruby-9.0.1.0/lib/ruby/stdlib/rubygems/version.rb:207:in `initialize'
    from /usr/local/rvm/rubies/jruby-9.0.1.0/lib/ruby/stdlib/rubygems/version.rb:198:in `new'
    from /usr/local/rvm/gems/jruby-9.0.1.0/gems/ffi-icu-0.1.7/lib/ffi-icu/lib.rb:240:in `<module:Lib>'
    from /usr/local/rvm/gems/jruby-9.0.1.0/gems/ffi-icu-0.1.7/lib/ffi-icu/lib.rb:8:in `<module:ICU>'
    from /usr/local/rvm/gems/jruby-9.0.1.0/gems/ffi-icu-0.1.7/lib/ffi-icu/lib.rb:1:in `<top>'
    from org/jruby/RubyKernel.java:939:in `require'
    from /usr/local/rvm/gems/jruby-9.0.1.0/gems/ffi-icu-0.1.7/lib/ffi-icu.rb:1:in `<top>'
    from org/jruby/RubyKernel.java:939:in `require'
    from /usr/local/rvm/gems/jruby-9.0.1.0/gems/ffi-icu-0.1.7/lib/ffi-icu.rb:33:in `<eval>'
    from org/jruby/RubyKernel.java:978:in `eval'
    from (irb):1:in `(root)'
    from (irb):1:in `evaluate'
    from org/jruby/RubyKernel.java:1291:in `loop'
    from org/jruby/RubyKernel.java:1098:in `catch'
    from org/jruby/RubyKernel.java:1098:in `catch'
    from /usr/local/rvm/gems/jruby-9.0.1.0/gems/bundler-1.10.6/lib/bundler/cli/console.rb:14:in `run'
    from /usr/local/rvm/gems/jruby-9.0.1.0/gems/bundler-1.10.6/lib/bundler/cli.rb:308:in `console'
    from /usr/local/rvm/gems/jruby-9.0.1.0/gems/bundler-1.10.6/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
    from /usr/local/rvm/gems/jruby-9.0.1.0/gems/bundler-1.10.6/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
    from /usr/local/rvm/gems/jruby-9.0.1.0/gems/bundler-1.10.6/lib/bundler/vendor/thor/lib/thor.rb:359:in `dispatch'
    from /usr/local/rvm/gems/jruby-9.0.1.0/gems/bundler-1.10.6/lib/bundler/vendor/thor/lib/thor/base.rb:440:in `block in start'
    from /usr/local/rvm/gems/jruby-9.0.1.0/gems/bundler-1.10.6/lib/bundler/cli.rb:10:in `start'
    from /usr/local/rvm/gems/jruby-9.0.1.0/gems/bundler-1.10.6/bin/bundle:20:in `<top>'
    from org/jruby/RubyKernel.java:957:in `load'
    from /usr/local/rvm/gems/jruby-9.0.1.0/gems/bundler-1.10.6/lib/bundler/friendly_errors.rb:7:in `<eval>'
    from org/jruby/RubyKernel.java:978:in `eval'
    from /usr/local/rvm/gems/jruby-9.0.1.0/bin/jruby_executable_hooks:15:in `<top>'
```
