### PR TITLE
Update CI to include Ruby 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 rvm:
-  - 2.4.6
-  - 2.5.5
-  - 2.6.3
+  - 2.4
+  - 2.5
+  - 2.6
+  - 2.7
   - ruby-head
 before_script:
   - sudo apt-get install -y libicu-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,18 @@
+language: ruby
+os: linux
+dist: xenial
+
 rvm:
   - 2.4
   - 2.5
   - 2.6
   - 2.7
   - ruby-head
+
 before_script:
   - sudo apt-get install -y libicu-dev
 
-matrix:
+jobs:
   allow_failures:
-    - rvm: ruby-head
     - rvm: 2.7
+    - rvm: ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,4 @@ before_script:
 matrix:
   allow_failures:
     - rvm: ruby-head
+    - rvm: 2.7

--- a/README.md
+++ b/README.md
@@ -130,15 +130,16 @@ Platforms:
 
 Rubies:
 
-- 2.4.6
-- 2.5.5
-- 2.6.3
+- 2.4
+- 2.5
+- 2.6
+- 2.7
 - ruby-head
 
 TODO:
 =====
 
-* Any other useful part of ICU? 
+* Any other useful part of ICU?
 * Windows?!
 
 Note on Patches/Pull Requests


### PR DESCRIPTION
This also simplifies the prior Ruby versions to let Travis pull the latest release (more [here](https://docs.travis-ci.com/user/languages/ruby/#specifying-ruby-versions-and-implementations)), and updates docs to match.

~This is blocked by https://github.com/erickguan/ffi-icu/pull/40 (which resolves current CI issues).~

📝 The last Ruby version updates in Travis were in https://github.com/erickguan/ffi-icu/pull/38/commits/f64f574a2c3e241281cfe9b7f85fd1c9f448ef6b