### PR TITLE
Add support for skeleton date patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Dependencies
 ICU.
 
 If you get messages that the library or functions are not found, you can
-set some environment varibles to tell ffi-icu where to find it, e.g.:
+set some environment variables to tell ffi-icu where to find it, e.g.:
 
     $ export FFI_ICU_LIB="icui18n.so"
     $ export FFI_ICU_VERSION_SUFFIX="_3_8"
@@ -109,14 +109,24 @@ Examples:
     f #=> "12.11.15 15:21"
 
     # reusable formatting objects
-    formater = ICU::TimeFormatting.create(:locale => 'cs_CZ', :zone => 'Europe/Prague', :date => :long , :time => :none)
-    formater.format(Time.now)  #=> "25. února 2015"
+    formatter = ICU::TimeFormatting.create(:locale => 'cs_CZ', :zone => 'Europe/Prague', :date => :long, :time => :none)
+    formatter.format(Time.now)  #=> "25. února 2015"
 ```
 
 ```ruby
     # reusable formatting objects
-    formater = ICU::TimeFormatting.create(:locale => 'cs_CZ', :zone => 'Europe/Prague', :date => :long , :time => :none)
-    formater.parse("25. února 2015") #=> Wed Feb 25 00:00:00 +0100 2015
+    formatter = ICU::TimeFormatting.create(:locale => 'cs_CZ', :zone => 'Europe/Prague', :date => :long, :time => :none)
+    formatter.parse("25. února 2015") #=> Wed Feb 25 00:00:00 +0100 2015
+```
+
+For skeleton formatting, visit the [Unicode date field symbol table](https://unicode-org.github.io/icu/userguide/format_parse/datetime/#date-field-symbol-table) to help find the pattern characters to use.
+
+```ruby
+    formatter = ICU::TimeFormatting.create(:locale => 'cs_CZ', :date => :pattern, :time => :pattern, :skeleton => 'MMMMY')
+    formatter.format(Time.now)  #=> "únor 2015"
+
+    formatter = ICU::TimeFormatting.create(:locale => 'cs_CZ', :date => :pattern, :time => :pattern, :skeleton => 'Y')
+    formatter.format(Time.now)  #=> "2015"
 ```
 
 Tested on:

--- a/lib/ffi-icu/lib.rb
+++ b/lib/ffi-icu/lib.rb
@@ -425,11 +425,12 @@ module ICU
     attach_function :unum_set_attribute, "unum_setAttribute#{suffix}", [:pointer, :number_format_attribute, :int32_t], :void
     # date
     enum :date_format_style, [
-      :none,  -1,
-      :full,   0,
-      :long,   1,
-      :medium, 2,
-      :short,  3,
+      :pattern, -2,
+      :none,    -1,
+      :full,    0,
+      :long,    1,
+      :medium,  2,
+      :short,   3,
     ]
     attach_function :udat_open, "udat_open#{suffix}", [:date_format_style, :date_format_style, :string, :pointer, :int32_t, :pointer, :int32_t, :pointer ], :pointer
     attach_function :udat_close, "unum_close#{suffix}", [:pointer], :void
@@ -437,6 +438,9 @@ module ICU
     attach_function :udat_parse, "udat_parse#{suffix}", [:pointer, :pointer, :int32_t,  :pointer, :pointer], :double
     attach_function :udat_toPattern, "udat_toPattern#{suffix}", [:pointer, :bool    , :pointer, :int32_t    , :pointer], :int32_t
     attach_function :udat_applyPattern, "udat_applyPattern#{suffix}", [:pointer, :bool    , :pointer, :int32_t     ], :void
+    # skeleton pattern
+    attach_function :udatpg_open, "udatpg_open#{suffix}", [:string, :pointer], :pointer
+    attach_function :udatpg_getBestPattern, "udatpg_getBestPattern#{suffix}", [:pointer, :pointer, :int32_t, :pointer, :int32_t, :pointer], :int32_t
     # tz
     attach_function :ucal_setDefaultTimeZone, "ucal_setDefaultTimeZone#{suffix}", [:pointer, :pointer], :int32_t
     attach_function :ucal_getDefaultTimeZone, "ucal_getDefaultTimeZone#{suffix}", [:pointer, :int32_t, :pointer], :int32_t

--- a/lib/ffi-icu/version.rb
+++ b/lib/ffi-icu/version.rb
@@ -1,3 +1,3 @@
 module ICU
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end

--- a/spec/time_spec.rb
+++ b/spec/time_spec.rb
@@ -59,7 +59,7 @@ module ICU
         expect(f2.format(t8)).to eq("3/29/08#{en_sep} 6:38:24 AM #{en_tz}")
       end
 
-      f3 = TimeFormatting.create(:locale => 'de_DE', :zone => 'Africa/Dakar ', :date => :short , :time => :long)
+      f3 = TimeFormatting.create(:locale => 'de_DE', :zone => 'Africa/Dakar', :date => :short , :time => :long)
       ge_sep = ""
       if cldr_version >= "27.0.1"
         ge_sep = ","
@@ -81,6 +81,19 @@ module ICU
         expect(f3.format(t6)).to eq("29.03.08#{ge_sep} 01:36:22 GMT")
         expect(f3.format(t7)).to eq("29.03.08#{ge_sep} 02:37:23 GMT")
         expect(f3.format(t8)).to eq("29.03.08#{ge_sep} 03:38:24 GMT")
+      end
+
+      context 'skeleton pattern' do
+        f4 = TimeFormatting.create(:locale => 'fr_FR', :date => :pattern , :time => :pattern, :skeleton => 'MMMy')
+
+        it 'check format' do
+          expect(f4.format(t0)).to eq("nov. 2008")
+          expect(f4.format(t1)).to eq("oct. 2008")
+        end
+
+        it 'check date_format' do
+          expect(f4.date_format(true)).to eq("MMM y")
+        end
       end
     end
   end

--- a/spec/time_spec.rb
+++ b/spec/time_spec.rb
@@ -84,7 +84,7 @@ module ICU
       end
 
       context 'skeleton pattern' do
-        f4 = TimeFormatting.create(:locale => 'fr_FR', :date => :pattern , :time => :pattern, :skeleton => 'MMMy')
+        f4 = TimeFormatting.create(:locale => 'fr_FR', :date => :pattern, :time => :pattern, :skeleton => 'MMMy')
 
         it 'check format' do
           expect(f4.format(t0)).to eq("nov. 2008")


### PR DESCRIPTION
Users will be able to provide [skeleton patterns](https://unicode-org.github.io/icu/userguide/format_parse/datetime/#date-field-symbol-table) to allow for a variety of date formats.

**Usage:**
`formatter = ICU::TimeFormatting.create(:locale => 'fr_FR', :date => :pattern, :time => :pattern, :skeleton => 'MMMMy')`
`formatter.format(Time.now) => "août 2021"`

**Pattern examples:**
`'MMMd' => 'Oct. 31'`
`'MMMMy' => 'October 2021'`
`'y' => '2021'`

**C code example:**
https://unicode-org.github.io/icu/userguide/format_parse/datetime/examples.html#c-7