### PR TITLE
Fix removal of Fixnum in ruby-next in number formatter

### DIFF
--- a/spec/number_formatting_spec.rb
+++ b/spec/number_formatting_spec.rb
@@ -69,6 +69,11 @@ module ICU
           expect { NumberFormatting.create('en-US', :currency, style: :iso) }.to raise_error(StandardError)
         end
       end
+
+      it 'should format a bignum' do
+        str = NumberFormatting.format_number("en", 1_000_000_000_000_000_000_000_000_000_000_000_000_000)
+        expect(str).to eq('1,000,000,000,000,000,000,000,000,000,000,000,000,000')
+      end
     end
   end # NumberFormatting
 end # ICU


### PR DESCRIPTION
The current ruby head removed Fixnum and Bignum classes, which has made
the build break. I also don't believe the Bignum support was allowing
the formatting of arbitrary bignums anyway.

Fix it by attempting to coalesce the passed-in number to an int64_t, and
if that fails, falling back to calling unum_format_decimal.