### PR TITLE
Add #as_skeleton and #set_date_format_from_skeleton to DateTimeFormatter

### DIFF
--- a/lib/ffi-icu/lib.rb
+++ b/lib/ffi-icu/lib.rb
@@ -439,6 +439,7 @@ module ICU
     # skeleton pattern
     attach_function :udatpg_open, "udatpg_open#{suffix}", [:string, :pointer], :pointer
     attach_function :udatpg_getBestPattern, "udatpg_getBestPattern#{suffix}", [:pointer, :pointer, :int32_t, :pointer, :int32_t, :pointer], :int32_t
+    attach_function :udatpg_getSkeleton, "udatpg_getSkeleton#{suffix}", [:pointer, :pointer, :int32_t, :pointer, :int32_t, :pointer], :int32_t
     # tz
     attach_function :ucal_setDefaultTimeZone, "ucal_setDefaultTimeZone#{suffix}", [:pointer, :pointer], :int32_t
     attach_function :ucal_getDefaultTimeZone, "ucal_getDefaultTimeZone#{suffix}", [:pointer, :int32_t, :pointer], :int32_t

--- a/spec/time_spec.rb
+++ b/spec/time_spec.rb
@@ -95,6 +95,69 @@ module ICU
           expect(f4.date_format(true)).to eq("MMM y")
         end
       end
+
+      context 'using skeleton patterns to manipulate 12/24 hour time' do
+        it 'can faithfully round-trip 12-hour time patterns' do
+          locale = ICU::Locale.new("en_AU@hours=h12")
+          formatter = ICU::TimeFormatting::DateTimeFormatter.new(
+            time: :long, date: :long, locale: locale.to_s, zone: 'UTC'
+          )
+          
+          sk = formatter.as_skeleton
+          sk.gsub!('a', '')
+          sk.gsub!(/[hHkK]/, 'j')
+          formatter.set_date_format_from_skeleton sk
+
+          formatted_t0 = formatter.format t0
+          expect(formatted_t0).to match(/[^0]2\:21/)
+          expect(formatted_t0).to match(/pm/i)
+        end
+        it 'can convert 12-hour patterns to 24 hour time' do
+          locale = ICU::Locale.new("en_AU@hours=h23")
+          formatter = ICU::TimeFormatting::DateTimeFormatter.new(
+            time: :long, date: :long, locale: locale.to_s, zone: 'UTC'
+          )
+          
+          sk = formatter.as_skeleton
+          sk.gsub!('a', '')
+          sk.gsub!(/[hHkK]/, 'j')
+          formatter.set_date_format_from_skeleton sk
+
+          formatted_t0 = formatter.format t0
+          expect(formatted_t0).to match(/14\:21/)
+          expect(formatted_t0).to_not match(/pm/i)
+        end
+        it 'can faithfully round-trip 24 hour time patterns' do
+          locale = ICU::Locale.new("en_FR@hours=h23")
+          formatter = ICU::TimeFormatting::DateTimeFormatter.new(
+            time: :long, date: :long, locale: locale.to_s, zone: 'UTC'
+          )
+          
+          sk = formatter.as_skeleton
+          sk.gsub!('a', '')
+          sk.gsub!(/[hHkK]/, 'j')
+          formatter.set_date_format_from_skeleton sk
+
+          formatted_t0 = formatter.format t0
+          expect(formatted_t0).to match(/14\:21/)
+          expect(formatted_t0).to_not match(/pm/i)
+        end
+        it 'can convert 24-hour patterns to 12 hour time' do
+          locale = ICU::Locale.new("en_FR@hours=h12")
+          formatter = ICU::TimeFormatting::DateTimeFormatter.new(
+            time: :long, date: :long, locale: locale.to_s, zone: 'UTC'
+          )
+          
+          sk = formatter.as_skeleton
+          sk.gsub!('a', '')
+          sk.gsub!(/[hHkK]/, 'j')
+          formatter.set_date_format_from_skeleton sk
+
+          formatted_t0 = formatter.format t0
+          expect(formatted_t0).to match(/[^0]2\:21/)
+          expect(formatted_t0).to match(/pm/i)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
As documented in the tests, the main purpose of this functionality is to
allow:
    * Loading up one of the standard date/time patterns :long, :short,
      etc
    * Converting it into a skeleton
    * Manipulating the skeleton somehow
    * Converting the skeleton back into a real pattern
    * Formatting a time with it

The use-case in question I have is being able to modify the standard
skeleton patterns to use `j` for locale-appropriate 12/24 hour time,
instead of H/h being specified per-locale. This means that locales with
hours keywords like "en_AU@hours=h23" can be made to produce 24 hour
time, which ICU would not normally do.