### PR TITLE
Add support for h11/h12/h23/h24 hour cycle

### DIFF
--- a/lib/ffi-icu/lib.rb
+++ b/lib/ffi-icu/lib.rb
@@ -434,6 +434,10 @@ module ICU
       :medium,  2,
       :short,   3,
     ]
+    enum :uloc_data_locale_type, [
+      :actual_locale, 0,
+      :valid_locale, 1,
+    ]
     attach_function :udat_open, "udat_open#{suffix}", [:date_format_style, :date_format_style, :string, :pointer, :int32_t, :pointer, :int32_t, :pointer ], :pointer
     attach_function :udat_close, "unum_close#{suffix}", [:pointer], :void
     attach_function :udat_format, "udat_format#{suffix}", [:pointer, :double, :pointer, :int32_t, :pointer, :pointer], :int32_t
@@ -444,6 +448,7 @@ module ICU
     attach_function :udatpg_open, "udatpg_open#{suffix}", [:string, :pointer], :pointer
     attach_function :udatpg_close, "udatpg_close#{suffix}", [:pointer], :void
     attach_function :udatpg_getBestPattern, "udatpg_getBestPattern#{suffix}", [:pointer, :pointer, :int32_t, :pointer, :int32_t, :pointer], :int32_t
+    attach_function :udatpg_getSkeleton, "udatpg_getSkeleton#{suffix}", [:pointer, :pointer, :int32_t, :pointer, :int32_t, :pointer], :int32_t
     # tz
     attach_function :ucal_setDefaultTimeZone, "ucal_setDefaultTimeZone#{suffix}", [:pointer, :pointer], :int32_t
     attach_function :ucal_getDefaultTimeZone, "ucal_getDefaultTimeZone#{suffix}", [:pointer, :int32_t, :pointer], :int32_t

--- a/lib/ffi-icu/lib/util.rb
+++ b/lib/ffi-icu/lib/util.rb
@@ -28,7 +28,19 @@ module ICU
         result.read_string(length)
       end
 
-      def self.read_uchar_buffer(length)
+      def self.read_uchar_buffer(length, &blk)
+        buf, len = read_uchar_buffer_as_ptr_impl(length, &blk)
+        buf.string(len)
+      end
+
+      def self.read_uchar_buffer_as_ptr(length, &blk)
+        buf, _ = read_uchar_buffer_as_ptr_impl(length, &blk)
+        buf
+      end
+
+      private
+
+      def self.read_uchar_buffer_as_ptr_impl(length)
         attempts = 0
 
         begin
@@ -40,7 +52,7 @@ module ICU
           raise BufferOverflowError, "needed: #{length}"
         end
 
-        result.string(length)
+        [result, length]
       end
     end
   end

--- a/lib/ffi-icu/uchar.rb
+++ b/lib/ffi-icu/uchar.rb
@@ -43,6 +43,10 @@ module ICU
       wstring.pack("U*")
     end
 
+    def length_in_uchars
+      size / type_size
+    end
+
 
   end # UCharPointer
 end # ICU

--- a/spec/time_spec.rb
+++ b/spec/time_spec.rb
@@ -95,6 +95,92 @@ module ICU
           expect(f4.date_format(true)).to eq("MMM y")
         end
       end
+
+      context 'hour cycle' do
+        # en_AU normally is 12 hours, fr_FR is normally 23 hours
+        ['en_AU', 'fr_FR', 'zh_CN'].each do |locale_name|
+          context "with locale #{locale_name}" do
+            it 'works with hour_cycle: h11' do
+              t = Time.new(2021, 04, 01, 12, 05, 0, "+00:00")
+              str = TimeFormatting.format(t, time: :short, date: :none, locale: locale_name, zone: 'UTC', hour_cycle: 'h11')
+              expect(str).to match(/0:05/i)
+              expect(str).to match(/(pm|下午)/i)
+            end
+
+            it 'works with hour_cycle: h12' do
+              t = Time.new(2021, 04, 01, 12, 05, 0, "+00:00")
+              str = TimeFormatting.format(t, time: :short, date: :none, locale: locale_name, zone: 'UTC', hour_cycle: 'h12')
+              expect(str).to match(/12:05/i)
+              expect(str).to match(/(pm|下午)/i)
+            end
+
+            it 'works with hour_cycle: h23' do
+              t = Time.new(2021, 04, 01, 00, 05, 0, "+00:00")
+              str = TimeFormatting.format(t, time: :short, date: :none, locale: locale_name, zone: 'UTC', hour_cycle: 'h23')
+              expect(str).to match(/0:05/i)
+              expect(str).to_not match(/(am|pm)/i)
+            end
+
+            it 'works with hour_cycle: h24' do
+              t = Time.new(2021, 04, 01, 00, 05, 0, "+00:00")
+              str = TimeFormatting.format(t, time: :short, date: :none, locale: locale_name, zone: 'UTC', hour_cycle: 'h24')
+              expect(str).to match(/24:05/i)
+              expect(str).to_not match(/(am|pm)/i)
+            end
+
+            context '@hours keyword' do
+              before(:each) do
+                skip("Only works on ICU >= 67") if Lib.version.to_a[0] < 67
+              end
+
+              it 'works with @hours=h11 keyword' do
+                t = Time.new(2021, 04, 01, 12, 05, 0, "+00:00")
+                locale = Locale.new(locale_name).with_keyword('hours', 'h11').to_s
+                str = TimeFormatting.format(t, time: :short, date: :none, locale: locale, zone: 'UTC', hour_cycle: :locale)
+                expect(str).to match(/0:05/i)
+                expect(str).to match(/(pm|下午)/i)
+              end
+              it 'works with @hours=h12 keyword' do
+                t = Time.new(2021, 04, 01, 12, 05, 0, "+00:00")
+                locale = Locale.new(locale_name).with_keyword('hours', 'h12').to_s
+                str = TimeFormatting.format(t, time: :short, date: :none, locale: locale, zone: 'UTC', hour_cycle: :locale)
+                expect(str).to match(/12:05/i)
+                expect(str).to match(/(pm|下午)/i)
+              end
+
+              it 'works with @hours=h23 keyword' do
+                t = Time.new(2021, 04, 01, 00, 05, 0, "+00:00")
+                locale = Locale.new(locale_name).with_keyword('hours', 'h23').to_s
+                str = TimeFormatting.format(t, time: :short, date: :none, locale: locale, zone: 'UTC', hour_cycle: :locale)
+                expect(str).to match(/0:05/i)
+                expect(str).to_not match(/(am|pm)/i)
+              end
+
+              it 'works with @hours=h24 keyword' do
+                t = Time.new(2021, 04, 01, 00, 05, 0, "+00:00")
+                locale = Locale.new(locale_name).with_keyword('hours', 'h24').to_s
+                str = TimeFormatting.format(t, time: :short, date: :none, locale: locale, zone: 'UTC', hour_cycle: :locale)
+                expect(str).to match(/24:05/i)
+                expect(str).to_not match(/(am|pm)/i)
+              end
+            end
+          end
+        end
+
+        it 'works with defaults on a h12 locale' do
+          t = Time.new(2021, 04, 01, 13, 05, 0, "+00:00")
+          str = TimeFormatting.format(t, time: :short, date: :none, locale: 'en_AU', zone: 'UTC', hour_cycle: :locale)
+          expect(str).to match(/1:05/i)
+          expect(str).to match(/pm/i)
+        end
+
+        it 'works with defaults on a h23 locale' do
+          t = Time.new(2021, 04, 01, 0, 05, 0, "+00:00")
+          str = TimeFormatting.format(t, time: :short, date: :none, locale: 'fr_FR', zone: 'UTC', hour_cycle: :locale)
+          expect(str).to match(/0:05/i)
+          expect(str).to_not match(/(am|pm)/i)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
The hour cycle can be directly specified to the call to #format, or
inferred from an "@hours=" keyword on the locale.

The algorithm for fixing up the skeletons & patterns is the same as that
used in Firefox:
https://github.com/tc39/ecma402/issues/665#issuecomment-1084833809

There are two main ways to call this API. Either `hour_cycle` can be specified directly, or it can be set to `:locale` in which case the `hours` keyword in the locale will be used.

```
irb(main):010:0> t = Time.new(2021, 04, 01, 13, 05, 0, "+00:00")
=> 2021-04-01 13:05:00 +0000
irb(main):011:0> ICU::TimeFormatting.format(t, zone: 'UTC', locale: 'en_AU', hour_cycle: 'h12')
=> "1/4/2021, 1:05 pm"
irb(main):012:0> ICU::TimeFormatting.format(t, zone: 'UTC', locale: 'en_AU', hour_cycle: 'h23')
=> "1/4/2021, 13:05"
irb(main):013:0> ICU::TimeFormatting.format(t, zone: 'UTC', locale: 'en_AU@hours=h12;', hour_cycle: :locale)
=> "1/4/2021, 1:05 pm"
irb(main):014:0> ICU::TimeFormatting.format(t, zone: 'UTC', locale: 'en_AU@hours=h23;', hour_cycle: :locale)
=> "1/4/2021, 13:05"
```