### PR TITLE
Allow overriding libicu on MacOS with FFI_ICU_LIB

### DIFF
--- a/lib/ffi-icu/lib.rb
+++ b/lib/ffi-icu/lib.rb
@@ -37,8 +37,12 @@ module ICU
                     [find_lib("libicui18n.#{FFI::Platform::LIBSUFFIX}.??"),
                      find_lib("libicutu.#{FFI::Platform::LIBSUFFIX}.??")]
                   when :osx
-                    # See https://developer.apple.com/documentation/macos-release-notes/macos-big-sur-11_0_1-release-notes (62986286)
-                    if Gem::Version.new(`sw_vers -productVersion`) >= Gem::Version.new('11')
+                    if ENV.key?('FFI_ICU_LIB')
+                      # Ensure we look in the user-supplied override dir for a user-compiled libicu
+                      [find_lib("libicui18n.??.#{FFI::Platform::LIBSUFFIX}"),
+                      find_lib("libicutu.??.#{FFI::Platform::LIBSUFFIX}")]
+                    elsif Gem::Version.new(`sw_vers -productVersion`) >= Gem::Version.new('11')
+                      # See https://developer.apple.com/documentation/macos-release-notes/macos-big-sur-11_0_1-release-notes (62986286)
                       ["libicucore.#{FFI::Platform::LIBSUFFIX}"]
                     else
                       [find_lib("libicucore.#{FFI::Platform::LIBSUFFIX}")]


### PR DESCRIPTION
I compiled ICU 71 rc1 on my macbook and needed to run the ffi-icu tests against it. I feel like FFI_ICU_LIB should work on MacOS too.