### PR TITLE
Don't add am/pm marker if there is no time in the format string

### DIFF
--- a/lib/ffi-icu/time_formatting.rb
+++ b/lib/ffi-icu/time_formatting.rb
@@ -254,7 +254,10 @@ module ICU
 
         # Either ensure the skeleton has, or does not have, am/pm, as appropriate
         if ['h11', 'h12'].include?(@hour_cycle)
-          skeleton_str << 'a' unless skeleton_str.include? 'a'
+          # Only actually append 'am/pm' if there is an hour in the format string
+          if skeleton_str =~ /[hHkKjJ]/ && !skeleton_str.include?('a')
+            skeleton_str << 'a'
+          end
         else
           skeleton_str.gsub!('a', '')
         end

--- a/spec/time_spec.rb
+++ b/spec/time_spec.rb
@@ -128,6 +128,12 @@ module ICU
               expect(str).to_not match(/(am|pm)/i)
             end
 
+            it 'does not include am/pm if time is not requested' do
+              t = Time.new(2021, 04, 01, 00, 05, 0, "+00:00")
+              str = TimeFormatting.format(t, time: :none, date: :short, locale: locale_name, zone: 'UTC', hour_cycle: 'h12')
+              expect(str).to_not match(/(am|pm|下午|上午)/i)
+            end
+
             context '@hours keyword' do
               before(:each) do
                 skip("Only works on ICU >= 67") if Lib.version.to_a[0] < 67


### PR DESCRIPTION
Currently, doing something like `format(time, time: :none, hour_cycle:
'h12')` will give a string like "10/04/2021 PM" - the am/pm marker is
added to the skeleton even though the skeleton has no other time
markers.