### PR TITLE
Don't replace quoted substr with hour cycle

### DIFF
--- a/lib/ffi-icu/time_formatting.rb
+++ b/lib/ffi-icu/time_formatting.rb
@@ -275,7 +275,7 @@ module ICU
         resolved_hour_cycle = @hour_cycle == :locale ? Locale.new(@locale).keyword('hours') : @hour_cycle
 
         if HOUR_CYCLE_SYMS.keys.include?(resolved_hour_cycle)
-          new_pattern_str.gsub!(/[hHkK]/, HOUR_CYCLE_SYMS[resolved_hour_cycle])
+          new_pattern_str.gsub!(/[hHkK](?=(?:[^\']|\'[^\']*\')*$)/, HOUR_CYCLE_SYMS[resolved_hour_cycle])
         end
 
         # Finally, set the new pattern onto the date time formatter

--- a/spec/time_spec.rb
+++ b/spec/time_spec.rb
@@ -173,6 +173,12 @@ module ICU
           end
         end
 
+        it 'for lang=fi hour_cycle=h12' do
+          t = Time.new(2021, 04, 01, 13, 05, 0, "+00:00")
+          str = TimeFormatting.format(t, locale: 'fi', zone: 'America/Los_Angeles', date: :long, time: :short, hour_cycle: 'h12')
+          expect(str).to match(/\sklo\s/)
+        end
+
         it 'works with defaults on a h12 locale' do
           t = Time.new(2021, 04, 01, 13, 05, 0, "+00:00")
           str = TimeFormatting.format(t, time: :short, date: :none, locale: 'en_AU', zone: 'UTC', hour_cycle: :locale)


### PR DESCRIPTION
This updated the regex (originally added in https://github.com/erickguan/ffi-icu/commit/514f145c1aa49347fdd7d59a9d3490068a4f14c2) to exclude any matching characters that are quoted (single quotes), addressing an issue with 12h formatting for Finnish where 'klo' ('at') became 'hlo' in the formatted output.

Closes https://github.com/erickguan/ffi-icu/issues/63