### PR TITLE
Display locale name with alternative territory name

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ curf.format(1234.56, 'USD') #=> "$1,234.56"
 ```
 
 Time Formatting/Parsing
---------------------------
+-----------------------
 
 Examples:
 
@@ -130,9 +130,8 @@ formatter = ICU::TimeFormatting.create(:locale => 'cs_CZ', :date => :pattern, :t
 formatter.format(Time.now)  #=> "2015"
 ```
 
-
 Duration Formatting
----------------
+-------------------
 
 ```ruby
 # What the various styles look like
@@ -177,7 +176,7 @@ formatter.format({hours: 5, minutes: 7, seconds: 23, milliseconds: 400, microsec
 formatter = ICU::DurationFormatting::DurationFormatter.new(locale: 'en-AU', style: :long)
 formatter.format({days: 2, hours: 7.3, minutes: 40.9, seconds:0.43})  #=> "2 days, 7 hours, 40 minutes, 0.43 seconds"
 
-# With RU locale 
+# With RU locale
 formatter = ICU::DurationFormatting::DurationFormatter.new(locale: 'ru', style: :long)
 formatter.format({hours: 1, minutes: 2, seconds: 3})  #=> "1 час 2 минуты 3 секунды"
 formatter = ICU::DurationFormatting::DurationFormatter.new(locale: 'ru', style: :long)
@@ -195,7 +194,20 @@ Example:
 
 ```ruby
 ICU::Transliteration.transliterate('Traditional-Simplified', '沈從文') # => "沈从文"
+```
 
+Locale
+------
+
+Examples:
+
+```ruby
+locale = ICU::Locale.new('en-US')
+locale.display_country('en-US') #=> "United States"
+locale.display_language('es') #=> "inglés"
+locale.display_name('es') #=> "inglés (Estados Unidos)"
+locale.display_name_with_context('en-US', [:length_short]) #=> "English (US)"
+locale.display_name_with_context('en-US', [:length_long])  #=> "English (United States)"
 ```
 
 TODO:

--- a/lib/ffi-icu/lib.rb
+++ b/lib/ffi-icu/lib.rb
@@ -500,5 +500,8 @@ module ICU
     attach_function :ucal_setDefaultTimeZone, "ucal_setDefaultTimeZone#{suffix}", [:pointer, :pointer], :int32_t
     attach_function :ucal_getDefaultTimeZone, "ucal_getDefaultTimeZone#{suffix}", [:pointer, :int32_t, :pointer], :int32_t
 
+    # ULocaleDisplayNames
+    attach_function :uldn_openForContext, "uldn_openForContext#{suffix}", [:string, :pointer, :int32_t, :pointer], :pointer
+    attach_function :uldn_localeDisplayName, "uldn_localeDisplayName#{suffix}", [:pointer, :string, :pointer, :int32_t, :pointer], :int32_t
   end # Lib
 end # ICU

--- a/lib/ffi-icu/lib.rb
+++ b/lib/ffi-icu/lib.rb
@@ -503,5 +503,6 @@ module ICU
     # ULocaleDisplayNames
     attach_function :uldn_openForContext, "uldn_openForContext#{suffix}", [:string, :pointer, :int32_t, :pointer], :pointer
     attach_function :uldn_localeDisplayName, "uldn_localeDisplayName#{suffix}", [:pointer, :string, :pointer, :int32_t, :pointer], :int32_t
+    attach_function :uldn_close, "uldn_close#{suffix}", [:pointer], :void
   end # Lib
 end # ICU

--- a/spec/locale_spec.rb
+++ b/spec/locale_spec.rb
@@ -123,6 +123,11 @@ module ICU
           expect(Locale.new('zh_CH').display_name('fr')).to eq('chinois (Suisse)')
         end
 
+        it 'returns the name using display context' do
+          expect(Locale.new('en_US').display_name_with_context('en_HK', [:length_full])).to eq('English (Hong Kong SAR China)')
+          expect(Locale.new('en_US').display_name_with_context('en_HK', [:length_short])).to eq('English (Hong Kong)')
+        end
+
         it 'returns the script' do
           expect(Locale.new('ja_Hira_JP').display_script('en')).to eq('Hiragana')
           expect(Locale.new('ja_Hira_JP').display_script('ru')).to eq('хирагана')
@@ -140,6 +145,7 @@ module ICU
           expect(Locale.new('en_VI').display_country('ccp')).to_not be_nil
           expect(Locale.new('yue_Hant').display_language('ccp')).to_not be_nil
           expect(Locale.new('en_VI').display_name('ccp')).to_not be_nil
+          expect(Locale.new('ccp').display_name_with_context('en_VI')).to_not be_nil
           expect(Locale.new('yue_Hant').display_script('ccp')).to_not be_nil
           expect(Locale.new('en_US_POSIX').display_variant('sl')).to_not be_nil
         end


### PR DESCRIPTION
Adding a new method that returns a locale's display name with a short alternative territory name. The ICU library provides the `uldn_openForContext()` function that helps you to specify different types of context you want to display the locale. This change only adds the display context for lengths `UDISPCTX_LENGTH_FULL` and `UDISPCTX_LENGTH_SHORT`. There are other display context options available from ICU that can be easily added to the `DISPLAY_CONTEXT` constant. 

Currently, this is the best option we have to display `alt-short` names that are available in CLDR. There is an open ICU ticket ([ICU-8462](https://unicode-org.atlassian.net/browse/ICU-8462)) from 2018 to add alternative display name variants for locale and territory, but unsure how long it will be until it's implemented and available.

**Examples of alternative names:**
![Screenshot 2023-10-30 at 3 29 51 PM](https://github.com/erickguan/ffi-icu/assets/643455/52fa8174-1a0b-4533-ba1a-0c20e7ec9f9b)

![Screenshot 2023-10-30 at 3 30 40 PM](https://github.com/erickguan/ffi-icu/assets/643455/ffb35724-0e8a-4988-8ef4-eadf52734d65)

[CLDR Territory data example](https://github.com/unicode-org/cldr-json/blob/main/cldr-json/cldr-localenames-full/main/en/territories.json#L152-L153)

### ICU References
- [uldn_openForContext()](https://unicode-org.github.io/icu-docs/apidoc/released/icu4c/uldnames_8h.html#ad4f49735fead5e85c7411d9b7cca279a)
- [Display Context options](https://unicode-org.github.io/icu-docs/apidoc/released/icu4c/udisplaycontext_8h.html#ac80aa1aceff6c7ad2e9f983a19d8d868)
