### PR TITLE
Flip locales for new Locale method

### DIFF
--- a/lib/ffi-icu/locale.rb
+++ b/lib/ffi-icu/locale.rb
@@ -104,9 +104,9 @@ module ICU
     def display_name_with_context(locale, contexts = [])
       contexts = DISPLAY_CONTEXT.select { |context| contexts.include?(context) }.values
 
-      with_locale_display_name(@id, contexts) do |locale_display_names|
+      with_locale_display_name(locale, contexts) do |locale_display_names|
         Lib::Util.read_uchar_buffer(256) do |buffer, status|
-          Lib.uldn_localeDisplayName(locale_display_names, locale, buffer, buffer.size, status)
+          Lib.uldn_localeDisplayName(locale_display_names, @id, buffer, buffer.size, status)
         end
       end
     end

--- a/spec/locale_spec.rb
+++ b/spec/locale_spec.rb
@@ -124,8 +124,8 @@ module ICU
         end
 
         it 'returns the name using display context' do
-          expect(Locale.new('en_US').display_name_with_context('en_HK', [:length_full])).to eq('English (Hong Kong SAR China)')
-          expect(Locale.new('en_US').display_name_with_context('en_HK', [:length_short])).to eq('English (Hong Kong)')
+          expect(Locale.new('en_HK').display_name_with_context('en_US', [:length_full])).to eq('English (Hong Kong SAR China)')
+          expect(Locale.new('en_HK').display_name_with_context('en_US', [:length_short])).to eq('English (Hong Kong)')
         end
 
         it 'returns the script' do
@@ -145,7 +145,7 @@ module ICU
           expect(Locale.new('en_VI').display_country('ccp')).to_not be_nil
           expect(Locale.new('yue_Hant').display_language('ccp')).to_not be_nil
           expect(Locale.new('en_VI').display_name('ccp')).to_not be_nil
-          expect(Locale.new('ccp').display_name_with_context('en_VI')).to_not be_nil
+          expect(Locale.new('en_VI').display_name_with_context('ccp')).to_not be_nil
           expect(Locale.new('yue_Hant').display_script('ccp')).to_not be_nil
           expect(Locale.new('en_US_POSIX').display_variant('sl')).to_not be_nil
         end


### PR DESCRIPTION
The initialize locale and method locale were switched when compared to the other Locale methods.

Previously:
```ruby
Locale.new(<locale_to_display_it_in>).display_name_with_context(<locale_to_display>, [:length_full])
```

Now:
```ruby
Locale.new(<locale_to_display>).display_name_with_context(<locale_to_display_it_in>, [:length_full])
```

Either really works, but I prefer to match the other [Locale](https://github.com/erickguan/ffi-icu?tab=readme-ov-file#locale) methods. 