### PR TITLE
Remove monkeypatch to String

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,4 @@
 
 ### Removed
 
+- Stop monkeypatching `String#bytesize` or `String#jlength`.

--- a/lib/ffi-icu.rb
+++ b/lib/ffi-icu.rb
@@ -20,7 +20,6 @@ module ICU
   end
 end
 
-require 'ffi-icu/core_ext/string'
 require 'ffi-icu/lib'
 require 'ffi-icu/lib/util'
 require 'ffi-icu/uchar'

--- a/lib/ffi-icu/break_iterator.rb
+++ b/lib/ffi-icu/break_iterator.rb
@@ -23,7 +23,7 @@ module ICU
       @text = str
 
       Lib.check_error do |err|
-        Lib.ubrk_setText(@iterator, UCharPointer.from_string(str), str.jlength, err)
+        Lib.ubrk_setText(@iterator, UCharPointer.from_string(str), str.size, err)
       end
     end
 

--- a/lib/ffi-icu/chardet.rb
+++ b/lib/ffi-icu/chardet.rb
@@ -24,7 +24,7 @@ module ICU
 
       def declared_encoding=(str)
         Lib.check_error do |ptr|
-          Lib.ucsdet_setDeclaredEncoding(@detector, str, str.bytesize, ptr)
+          Lib.ucsdet_setDeclaredEncoding(@detector, str, str.size, ptr)
         end
       end
 
@@ -75,7 +75,7 @@ module ICU
       def set_text(text) # rubocop:disable Naming/AccessorMethodName
         Lib.check_error do |status|
           data = FFI::MemoryPointer.from_string(text)
-          Lib.ucsdet_setText(@detector, data, text.bytesize, status)
+          Lib.ucsdet_setText(@detector, data, text.size, status)
         end
       end
     end

--- a/lib/ffi-icu/collation.rb
+++ b/lib/ffi-icu/collation.rb
@@ -74,19 +74,19 @@ module ICU
       def compare(a, b)
         Lib.ucol_strcoll(
           @c,
-          UCharPointer.from_string(a), a.jlength,
-          UCharPointer.from_string(b), b.jlength
+          UCharPointer.from_string(a), a.size,
+          UCharPointer.from_string(b), b.size
         )
       end
 
       def greater?(a, b)
-        Lib.ucol_greater(@c, UCharPointer.from_string(a), a.jlength,
-                         UCharPointer.from_string(b), b.jlength)
+        Lib.ucol_greater(@c, UCharPointer.from_string(a), a.size,
+                         UCharPointer.from_string(b), b.size)
       end
 
       def greater_or_equal?(a, b)
-        Lib.ucol_greaterOrEqual(@c, UCharPointer.from_string(a), a.jlength,
-                                UCharPointer.from_string(b), b.jlength)
+        Lib.ucol_greaterOrEqual(@c, UCharPointer.from_string(a), a.size,
+                                UCharPointer.from_string(b), b.size)
       end
 
       def equal?(*args)
@@ -96,8 +96,8 @@ module ICU
 
         a, b = args
 
-        Lib.ucol_equal(@c, UCharPointer.from_string(a), a.jlength,
-                       UCharPointer.from_string(b), b.jlength)
+        Lib.ucol_equal(@c, UCharPointer.from_string(a), a.size,
+                       UCharPointer.from_string(b), b.size)
       end
 
       def collate(sortable)
@@ -116,9 +116,9 @@ module ICU
 
       def collation_key(string)
         ptr = UCharPointer.from_string(string)
-        size = Lib.ucol_getSortKey(@c, ptr, string.jlength, nil, 0)
+        size = Lib.ucol_getSortKey(@c, ptr, string.size, nil, 0)
         buffer = FFI::MemoryPointer.new(:char, size)
-        Lib.ucol_getSortKey(@c, ptr, string.jlength, buffer, size)
+        Lib.ucol_getSortKey(@c, ptr, string.size, buffer, size)
         buffer.read_bytes(size - 1)
       end
 

--- a/lib/ffi-icu/core_ext/string.rb
+++ b/lib/ffi-icu/core_ext/string.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-class String
-  alias bytesize length unless method_defined?(:bytesize)
-
-  alias jlength length unless method_defined?(:jlength)
-end

--- a/lib/ffi-icu/normalization.rb
+++ b/lib/ffi-icu/normalization.rb
@@ -3,7 +3,7 @@
 module ICU
   module Normalization
     def self.normalize(input, mode = :default)
-      input_length  = input.jlength
+      input_length  = input.size
       needed_length = out_length = options = 0
       in_ptr        = UCharPointer.from_string(input)
       out_ptr       = UCharPointer.new(out_length)

--- a/lib/ffi-icu/normalizer.rb
+++ b/lib/ffi-icu/normalizer.rb
@@ -11,7 +11,7 @@ module ICU
     end
 
     def normalize(input)
-      input_length  = input.jlength
+      input_length  = input.size
       in_ptr        = UCharPointer.from_string(input)
       needed_length = capacity = 0
       out_ptr       = UCharPointer.new(needed_length)
@@ -35,7 +35,7 @@ module ICU
     end
 
     def is_normailzed?(input) # rubocop:disable Naming/PredicateName
-      input_length  = input.jlength
+      input_length  = input.size
       in_ptr        = UCharPointer.from_string(input)
 
       Lib.check_error do |error|

--- a/lib/ffi-icu/number_formatting.rb
+++ b/lib/ffi-icu/number_formatting.rb
@@ -84,13 +84,13 @@ module ICU
                                     'ICU version is too old to have unum_format_decimal')
                 end
                 string_version = number.to_s
-                needed_length = Lib.unum_format_decimal(@f, string_version, string_version.bytesize, out_ptr,
+                needed_length = Lib.unum_format_decimal(@f, string_version, string_version.size, out_ptr,
                                                         needed_length, nil, error)
               end
             when BigDecimal
               string_version = number.to_s('F')
               needed_length = if Lib.respond_to?(:unum_format_decimal)
-                                Lib.unum_format_decimal(@f, string_version, string_version.bytesize, out_ptr,
+                                Lib.unum_format_decimal(@f, string_version, string_version.size, out_ptr,
                                                         needed_length, nil, error)
                               else
                                 Lib.unum_format_double(@f, number.to_f, out_ptr, needed_length, nil, error)

--- a/lib/ffi-icu/transliteration.rb
+++ b/lib/ffi-icu/transliteration.rb
@@ -26,14 +26,14 @@ module ICU
         rules_length = 0
 
         if rules
-          rules_length = rules.jlength + 1
+          rules_length = rules.size + 1
           rules = UCharPointer.from_string(rules)
         end
 
         parse_error = Lib::UParseError.new
         begin
           Lib.check_error do |status|
-            ptr = Lib.utrans_openU(UCharPointer.from_string(id), id.jlength, direction, rules, rules_length,
+            ptr = Lib.utrans_openU(UCharPointer.from_string(id), id.size, direction, rules, rules_length,
                                    @parse_error, status)
             @tr = FFI::AutoPointer.new(ptr, Lib.method(:utrans_close))
           end


### PR DESCRIPTION
Stops monkeypatching `String`.

Also replace `.jlength` by `.bytesize`.