### PR TITLE
Support icu naming conventions for msys2 on windows.

### DIFF
--- a/lib/ffi-icu/lib.rb
+++ b/lib/ffi-icu/lib.rb
@@ -50,8 +50,8 @@ module ICU
             [find_lib("libicucore.#{FFI::Platform::LIBSUFFIX}")]
           end
         when :windows
-          [find_lib("icuuc??.#{FFI::Platform::LIBSUFFIX}"),
-           find_lib("icuin??.#{FFI::Platform::LIBSUFFIX}")]
+          [find_lib("{lib,}icuuc??.#{FFI::Platform::LIBSUFFIX}"),
+           find_lib("{lib,}icuin??.#{FFI::Platform::LIBSUFFIX}")]
         end
 
       lib_names&.compact!


### PR DESCRIPTION
Supersede #35