### PR TITLE
Use Trusting Publishing (OIDC) to release gem

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Lint YAML
         run: yamllint .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Release
+
+on:
+  workflow_dispatch: # allow repo collaborators to publish gem
+
+permissions:
+  contents: write # required for `rake release` to push the release tag
+  id-token: write # required for workflow to publish gem
+
+jobs:
+  package-linting:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # required to run `rake release`.
+      - name: Setup Ruby and install dependencies
+        uses: ruby/setup-ruby@v1
+        with:
+          # setup-ruby implicitly uses .ruby-version
+          bundler-cache: true
+
+      # Run `rake release` to create git tag and push to repository based on `lib/version.rb`.
+      # Then publish the new gem via trusted publishing
+      # Read more on https://guides.rubygems.org/trusted-publishing/releasing-gems/
+      - uses: rubygems/release-gem@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # required to run `rake release`.
       - name: Setup Ruby and install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Ruby and install dependencies
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
This PR improves security on publishing the gem by utilizing [Trusting Publishing](https://guides.rubygems.org/trusted-publishing/).

I have configured Rubygems. My plan is to make a release and then enforce this trusting publishing.