### PR TITLE
Loosen bigdecimal version constraint

### DIFF
--- a/ffi-icu.gemspec
+++ b/ffi-icu.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 3.2.0'
 
-  spec.add_dependency('bigdecimal', '~> 3.1')
+  spec.add_dependency('bigdecimal', '>= 3.1')
   spec.add_dependency('ffi', '~> 1.0', '>= 1.0.9')
   spec.add_dependency('stringio', '~> 3.0')
 


### PR DESCRIPTION
The `~> 3.1` pessimistic constraint added in 2001f1307c0ae686bac839da95e3d290a60668a8 restricts consumers to bigdecimal 3.x. However, ffi-icu's actual use of `BigDecimal` is narrow — a single `case` branch in `NumberFormatting::BaseFormatter#format` that calls `BigDecimal#to_s('F')`:

https://github.com/erickguan/ffi-icu/blob/v0.6.0/lib/ffi-icu/number_formatting.rb#L90-L97

`BigDecimal#to_s('F')` is stable across both 3.x and 4.x — none of the documented 4.0 breaking changes affect it:

- `BigDecimal#divmod` return type change ([bigdecimal CHANGES.md#4.0.0](https://github.com/ruby/bigdecimal/blob/master/CHANGES.md))
- `BigDecimal#precs` removal
- `bigdecimal/{jacobian,ludcmp,newton}` deprecations

### Motivation

The tight pin forces a version downgrade on apps that already resolve `bigdecimal` 4.x through other paths — most commonly as a bundled gem on Ruby 3.4+ or transitively through `activesupport`. In the app I was investigating, bumping ffi-icu 0.5.3 → 0.6.0 caused Bundler to resolve `bigdecimal` from 4.1.2 down to 3.3.1, which is worse than leaving it alone.

Changing the constraint to `>= 3.1` lets consumers keep whichever version Bundler resolves without introducing regressions on unrelated numeric code paths.