### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,11 +55,9 @@ jobs:
 
       - name: Install ICU on macOS
         if: runner.os == 'macOS'
-        run: brew install icu4c
+        run: |
+          brew install icu4c
+          echo "FFI_ICU_LIB=$(brew --prefix icu4c)/lib" >> "$GITHUB_ENV"
 
       - name: Run tests
-        run: |
-          if [[ "$RUNNER_OS" == "macOS" ]]; then
-            export FFI_ICU_LIB="$(brew --prefix icu4c)/lib"
-          fi
-          bundle exec rake spec
+        run: bundle exec rake spec


### PR DESCRIPTION
Set `FFI_ICU_LIB` on macOS runners via `$GITHUB_ENV` so the value persists into the test step. The previous approach exported it inline in the test step, which failed on Windows where the run step executes in PowerShell; splitting env setup from the test command keeps the run step shell-agnostic.

Example failure from before this change: https://github.com/erickguan/ffi-icu/actions/runs/28539526377/job/84609713384