### PR TITLE
CI: install ICU on Windows runners

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,5 +59,28 @@ jobs:
           brew install icu4c
           echo "FFI_ICU_LIB=$(brew --prefix icu4c)/lib" >> "$GITHUB_ENV"
 
+      - name: Install ICU on Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $version = '78.3'
+          $zipName = "icu4c-$version-Win64-MSVC2022.zip"
+          $url = "https://github.com/unicode-org/icu/releases/download/release-$version/$zipName"
+          Invoke-WebRequest -Uri $url -OutFile $zipName
+          Expand-Archive -Path $zipName -DestinationPath C:\icu -Force
+          # Copy the DLLs next to ruby.exe. Modern Ruby on Windows calls
+          # SetDefaultDllDirectories(LOAD_LIBRARY_SEARCH_DEFAULT_DIRS), which
+          # excludes PATH from the search used to resolve a DLL's transitive
+          # dependencies — so having C:\icu\bin64 on PATH lets ffi-icu's
+          # find_lib locate icuuc??.dll, but Windows then fails to load
+          # icudt??.dll from the same directory (error 126). The application
+          # directory (ruby.exe's directory) is always searched first, so
+          # placing all ICU DLLs there resolves both the lookup and the
+          # transitive deps. ruby/setup-ruby prepends ruby.exe's directory
+          # to PATH, so find_lib finds icuuc??.dll here before any stale
+          # icuuc*.dll on the runner image (e.g. c:\tools\php).
+          $rubyBin = (Get-Command ruby).Source | Split-Path
+          Copy-Item C:\icu\bin64\icu*.dll -Destination $rubyBin -Force
+
       - name: Run tests
         run: bundle exec rake spec


### PR DESCRIPTION
## Summary
- Adds an "Install ICU on Windows" step to the test workflow that downloads the official `unicode-org/icu` Win64 MSVC2022 build (v78.3) and copies its DLLs into `ruby.exe`'s directory.

## Why the Windows job was failing
The `windows-2022` runner image has no working ICU. `Lib.find_lib` globs `PATH` for `icuuc??.dll` / `icuin??.dll` and picks up `c:\tools\php\icuuc77.dll` from the runner's Chocolatey PHP install, but its sibling `icudt77.dll` / `icuin77.dll` are missing, so `LoadLibrary` fails with Windows error 126. The outer rescue in `lib/ffi-icu/lib.rb` re-raises this as `no idea how to load ICU on :windows`.

## Why the DLLs go next to `ruby.exe` (and not just on `PATH`)
Two things have to be true for the load to succeed:

- `find_lib` must return an `icuuc??.dll` whose siblings actually exist. Copying into `ruby.exe`'s directory works because `ruby/setup-ruby` prepends that directory to `PATH`, so `find_lib` finds the new `icuuc78.dll` ahead of the stale one in `c:\tools\php`.
- Windows must be able to resolve the loaded DLL's transitive dependencies (`icudt78.dll`, `icuin78.dll`, VC++ runtime). Modern Ruby on Windows calls `SetDefaultDllDirectories(LOAD_LIBRARY_SEARCH_DEFAULT_DIRS)`, which excludes `PATH` from that search — so merely putting `C:\icu\bin64` on `PATH` is not enough (verified: it still fails with error 126). The application directory is always searched first regardless of policy, so placing the DLLs next to `ruby.exe` resolves both problems.

Naming (`icuuc78.dll`, `icuin78.dll`) already matches the loader's `{lib,}icuuc??.dll` glob and the `(\d\d)\.dll` version-detection regex, so no changes to `lib/ffi-icu/lib.rb` are needed.

## Test plan
- [x] Verified green on `windows-2022, 4.0` via my fork's CI: https://github.com/bquorning/ffi-icu/pull/1.
- [x] Other matrix jobs (Ubuntu / macOS) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)